### PR TITLE
updating python pkgs to match what nixos currently use

### DIFF
--- a/svpn-login.nix
+++ b/svpn-login.nix
@@ -9,7 +9,7 @@ in
   pkgs.stdenv.mkDerivation {
     name = "svpn-login";
     nativeBuildInputs = [ pkgs.dpkg pkgs.autoPatchelfHook ];
-    buildInputs = with pkgs; [ (python37.withPackages (ps: [ps.requests])) ];
+    buildInputs = with pkgs; [ (python38.withPackages (ps: [ps.requests])) ];
     unpackPhase = ":";
     installPhase = ''
       dpkg -x ${./linux_f5vpn.x86_64.deb} $out


### PR DESCRIPTION
Because currently NixOS is using python 3.8, I want to match what it is using to reduce duplication python version when I start nix-shell.